### PR TITLE
FRONT-07: Ajustando o Slick manualmente para aparecer somente no responsivo

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -490,6 +490,7 @@
     color: var(--cor-terciaria);
 }
 
+
 @media (max-width: 992px) {
     #kit-party .card {
         width: 31%;
@@ -507,7 +508,7 @@
         width: 100%;
         margin-top: 20px;
         text-align: justify;
-    }
+    }   
 }
 
 @media (max-width: 466px) {

--- a/index.html
+++ b/index.html
@@ -192,7 +192,7 @@
                 </p>
             </div>
 
-            <div class="d-none d-md-flex justify-content-lg-center align-items-lg-center gap-md-4 gap-lg-5">
+            <div class="response-kits d-md-flex justify-content-lg-center align-items-lg-center gap-md-4 gap-lg-5">
                 <div class="card">
                     <a href="conteudo-cards.html">
                         <div class="card-img">

--- a/js/response-kits.js
+++ b/js/response-kits.js
@@ -1,22 +1,39 @@
-$(".response-kits").slick({
-    dots: true,
-    infinite: false,
-    speed: 300,
-    responsive: [
-        {
-            breakpoint: 768,
-            settings: {
-                slidesToShow: 2,
-                slidesToScroll: 2
-            }
-        },
-        {
-            breakpoint: 480,
-            settings: {
-                slidesToShow: 1,
-                slidesToScroll: 1
-            }
-        }
-    ]
+function initSlick() {
 
+    if ($(window).width() <= 768) {
+
+        if (!$('.response-kits').hasClass('slick-initialized')) {
+
+            $('.response-kits').slick({
+                dots: true,
+                infinite: false,
+                speed: 300,
+                slidesToShow: 2,
+                slidesToScroll: 2,
+                responsive: [
+                    {
+                        breakpoint: 480,
+                        settings: {
+                            slidesToShow: 1,
+                            slidesToScroll: 1
+                        }
+                    }
+                ]
+            });
+
+        }
+
+    } else {
+
+        if ($('.response-kits').hasClass('slick-initialized')) {
+            $('.response-kits').slick('unslick');
+        }
+
+    }
+}
+
+initSlick();
+
+$(window).on('resize', function () {
+    initSlick();
 });


### PR DESCRIPTION
Problema:
-Na página Home, os cards no modo mobile não estavam aparecendo. Chamei a classe do JS no HTML, e estava aparentemente resolvido, só que, após o redimensionamento da tela acima de 768px, o carrossel do Slick permanecia ativo e fazia com que a seção de cards continuasse com comportamento de slider no desktop em vez de retornar ao layout em flex.

Solução:
-Adicionada inicialização condicional do Slick de acordo com o tamanho da tela.
Implementado unslick() para destruir o carrossel em resoluções acima de 768px.
Adicionada verificação slick-initialized para evitar múltiplas inicializações.